### PR TITLE
Add links to past talks

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,3 +4,17 @@ Community driven talk proposals and discussions for Node.js Houston.
 ## Goal
 
 Talks given at Node.js Houston are encouraged to be given by developers who attend the event. We are wanting to make sure everyone has a say in what they want to learn and teach. If there is a talk you would like to see or talk you want to give just create an issue. Anyone can give feedback and we want to be fully open. Only positive and constructive feedback. We are people after all. 😃
+
+## Past Talks
+
+ > If we keep up with the "Talks as GitHub Issues" format, the `README.md` can link to the closed issues with discussion, links, etc.
+ >
+ > Eric Clemmons
+
+ - [Making Languages in JavaScript, Matt Hall](http://nodejshouston.com/review-september-meetup/)
+ - [An Experiment in IoT Using Node.js, johnny-five, MQTT & Hardware, Pierce Primm](http://nodejshouston.com/review-september-meetup/)
+ - [GraphQL, Eric Clemmons](http://nodejshouston.com/a-look-ahead/)
+ - [The Future of the Web and the Rise of 3-D Content, John Rodney](http://nodejshouston.com/a-look-ahead/)
+ - [Simplifying Server Routes, Saul Maddox](http://nodejshouston.com/simplifying-server-routes-and-an-introduction-to-meteor/)
+ - [Introduction to Meteor, Matt Hager](http://nodejshouston.com/simplifying-server-routes-and-an-introduction-to-meteor/)
+ - [Teaching More Effectively, Matt Keas](http://nodejshouston.com/matt-keas-teaching-more-effectively/)


### PR DESCRIPTION
This is just an idea, but if people have any interest in providing more comprehensive links, slides, demos, etc. they might open an issue and then update the `README` to link into it OR SOMETHING TOTALLY DIFFERENT.
